### PR TITLE
Implement component for running signing page Javascript

### DIFF
--- a/app/components/signin-code.js
+++ b/app/components/signin-code.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  didInsertElement() {
+    this._super(...arguments);
+
+    let $ = this.$.bind(this);
+
+    $('input').blur(function () {
+        var $this = $(this);
+        if ($this.val())
+            $this.addClass('typed');
+        else
+            $this.removeClass('typed');
+    });
+  }
+});

--- a/app/routes/signin.js
+++ b/app/routes/signin.js
@@ -1,15 +1,3 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({});
-
-
-Ember.$(window, document, undefined).ready(function () {
-
-    Ember.$('input').blur(function () {
-        var $this = Ember.$(this);
-        if ($this.val())
-            $this.addClass('typed');
-        else
-            $this.removeClass('typed');
-    });
-});

--- a/app/templates/signin.hbs
+++ b/app/templates/signin.hbs
@@ -1,22 +1,24 @@
-<div class="container" id="signinpage">
-    <form>
-        <h1 class="formHeader"> Sign in </h1><br>
-        <div class="loginGroup">
-            <input type="email" name="useremail" required><span class="highlight"></span><span class="bar"></span>
-            <label>User Email</label>
-        </div>
-        <div class="loginGroup">
-            <input type="password" name="psw" required><span class="highlight"></span><span class="bar"></span>
-            <label>Password</label>
-            <div class="notification">
-                <i class="fa fa-exclamation-circle" aria-hidden="true"></i>The initial password should be the sign-in code sent to your email by the Block Project team.
-                <a href="#">
-                    <span class="getCode"> Didn't get a code? </span>
-                </a>
+{{#signin-code}}
+    <div class="container" id="signinpage">
+        <form>
+            <h1 class="formHeader"> Sign in </h1><br>
+            <div class="loginGroup">
+                <input type="email" name="useremail" required><span class="highlight"></span><span class="bar"></span>
+                <label>User Email</label>
             </div>
-        </div>
-        <button type="button" class="button buttonOrange">Enter</button>
+            <div class="loginGroup">
+                <input type="password" name="psw" required><span class="highlight"></span><span class="bar"></span>
+                <label>Password</label>
+                <div class="notification">
+                    <i class="fa fa-exclamation-circle" aria-hidden="true"></i>The initial password should be the sign-in code sent to your email by the Block Project team.
+                    <a href="#">
+                        <span class="getCode"> Didn't get a code? </span>
+                    </a>
+                </div>
+            </div>
+            <button type="button" class="button buttonOrange">Enter</button>
 
-        <div class="resetPassword"> <a href="#">Forget your password?</a></div>
-    </form>
-</div>
+            <div class="resetPassword"> <a href="#">Forget your password?</a></div>
+        </form>
+    </div>
+{{/signin-code}}


### PR DESCRIPTION
The basic idea here is that we can use Ember components to make sure we're only running our jQuery logic on a specific page, and it won't run on other pages. Ember will automatically call a component's `didInsertElement` method after it and everything it contains have been rendered, so it's a good time to set up event listeners and whatnot, because you know everything "inside" the component is already there and ready to go. Components also have a `this.$()` method that acts just like jQuery's global `$` method, except when being used to find elements by a selector, it will only match elements contained within the component.

So, you'll see in this pull request that I added a `app/components/signin-code.js`. That ends up allowing me to put

```hbs
{{#signin-code}}
    {{!-- whatever HTML I want --}}
{{/signin-code}}
```

in my template, and the jQuery I put in `signin-code.js` will run as I described above.

So, whenever you write a new route, like maybe `main.js`, you can just copy `app/components/signin-code.js` to `app/components/main-code.js`, delete the contents of `didInsertElement()` (except for the first two lines), write whatever jQuery code you need, and then wrap your `main.hbs` file in `{{#main-code}} ... {{/main-code}}`.