### PR TITLE
Hided backyard images for Host profile

### DIFF
--- a/app/templates/auth/host/activities.hbs
+++ b/app/templates/auth/host/activities.hbs
@@ -1,7 +1,7 @@
 {{#profile-page
   changeset=this.changeset
   backRoute="auth.host.location"
-  nextRoute="auth.host.photos"
+  nextRoute="auth.host.review2"
 as |page|
 }}
   {{#page.left-column}}

--- a/app/templates/auth/host/review2.hbs
+++ b/app/templates/auth/host/review2.hbs
@@ -7,7 +7,7 @@
 
     {{profile-page/footer
       percent=70
-      backRoute="auth.host.photos"
+      backRoute="auth.host.activities"
       nextRoute="auth.host.question"
     }}
   </div>

--- a/app/templates/components/host-profile.hbs
+++ b/app/templates/components/host-profile.hbs
@@ -1,4 +1,5 @@
 <div class="container profile-page view-profile">
+  {{!-- Hide the backyard photos temporarily
   <div class="row">
     <div class="col-12 carousel-section">
       {{#carousel-container transitionInterval=400 as |ui controls|}}
@@ -28,7 +29,7 @@
         <div role="button" class="arrow right" onclick={{controls.next}}></div>
       {{/carousel-container}}
     </div>
-  </div>
+  </div> --}}
 
   <div class="row summary">
     <div class="col-2">

--- a/app/templates/components/profile-page/review-page.hbs
+++ b/app/templates/components/profile-page/review-page.hbs
@@ -22,7 +22,6 @@
   }}
     {{#section.checklist-item route="auth.host.location"}}Location{{/section.checklist-item}}
     {{#section.checklist-item route="auth.host.activities"}}Activities{{/section.checklist-item}}
-    {{#section.checklist-item route="auth.host.photos"}}Photos{{/section.checklist-item}}
   {{/profile-page/review-page/section}}
 
   {{#profile-page/review-page/section

--- a/tests/acceptance/host/profile-test.js
+++ b/tests/acceptance/host/profile-test.js
@@ -10,7 +10,7 @@ import aboutPage from '../../pages/host/about';
 import review1Page from '../../pages/host/review1';
 import locationPage from '../../pages/host/location';
 import activitiesPage from '../../pages/host/activities';
-import photosPage from '../../pages/host/photos';
+// import photosPage from '../../pages/host/photos';
 import review2Page from '../../pages/host/review2';
 import questionPage from '../../pages/host/question';
 import review3Page from '../../pages/host/review3';
@@ -126,14 +126,14 @@ module('Acceptance | host/profile', function(hooks) {
     assert.equal(mirageUser.profile.backyardDescription, 'A small but comfy space');
 
     // Photos
-    assert.equal(currentRouteName(), 'auth.host.photos');
-    await photosPage.photos.objectAt(0).setImage(new File([ imageBlob ], 'foo.jpg', { type: 'image/jpeg' }));
-    await photosPage.photos.objectAt(1).setImage(new File([ imageBlob ], 'foo.jpg', { type: 'image/jpeg' }));
-    await photosPage.photos.objectAt(2).setImage(new File([ imageBlob ], 'foo.jpg', { type: 'image/jpeg' }));
-    await photosPage.photos.objectAt(3).setImage(new File([ imageBlob ], 'foo.jpg', { type: 'image/jpeg' }));
-    await photosPage.footer.next();
+    // assert.equal(currentRouteName(), 'auth.host.photos');
+    // await photosPage.photos.objectAt(0).setImage(new File([ imageBlob ], 'foo.jpg', { type: 'image/jpeg' }));
+    // await photosPage.photos.objectAt(1).setImage(new File([ imageBlob ], 'foo.jpg', { type: 'image/jpeg' }));
+    // await photosPage.photos.objectAt(2).setImage(new File([ imageBlob ], 'foo.jpg', { type: 'image/jpeg' }));
+    // await photosPage.photos.objectAt(3).setImage(new File([ imageBlob ], 'foo.jpg', { type: 'image/jpeg' }));
+    // await photosPage.footer.next();
 
-    mirageUser.reload();
+    // mirageUser.reload();
 
     // Review2
     assert.equal(currentRouteName(), 'auth.host.review2');
@@ -153,10 +153,10 @@ module('Acceptance | host/profile', function(hooks) {
 
     // Profile
     assert.equal(currentRouteName(), 'auth.host.profile');
-    assert.equal(profilePage.photos.objectAt(0).src, 'http://s3.amazon.com/download1');
-    assert.equal(profilePage.photos.objectAt(1).src, 'http://s3.amazon.com/download2');
-    assert.equal(profilePage.photos.objectAt(2).src, 'http://s3.amazon.com/download3');
-    assert.equal(profilePage.photos.objectAt(3).src, 'http://s3.amazon.com/download4');
+    // assert.equal(profilePage.photos.objectAt(0).src, 'http://s3.amazon.com/download1');
+    // assert.equal(profilePage.photos.objectAt(1).src, 'http://s3.amazon.com/download2');
+    // assert.equal(profilePage.photos.objectAt(2).src, 'http://s3.amazon.com/download3');
+    // assert.equal(profilePage.photos.objectAt(3).src, 'http://s3.amazon.com/download4');
     assert.equal(profilePage.profilePic, 'http://s3.amazon.com/download0');
     assert.equal(profilePage.name, 'The Bluth family');
     assert.equal(profilePage.gender, 'Male');
@@ -193,8 +193,8 @@ module('Acceptance | host/profile', function(hooks) {
     await questionPage.footer.back();
     assert.equal(currentRouteName(), 'auth.host.review2');
     await review2Page.footer.back();
-    assert.equal(currentRouteName(), 'auth.host.photos');
-    await photosPage.footer.back();
+    // assert.equal(currentRouteName(), 'auth.host.photos');
+    // await photosPage.footer.back();
     assert.equal(currentRouteName(), 'auth.host.activities');
     await activitiesPage.footer.back();
     assert.equal(currentRouteName(), 'auth.host.location');


### PR DESCRIPTION
Below are changes made based on the matching process adjustment (listed in the bottom of this comment)
- Hid the backyard-images uploading page by changing the page links on Activity Page and Review2 Page
- Hid the backyard-images section on the Host Profile Page
- Removed the Photos link on Review2 Page 

**Matching Process Adjustment**
The process has changed to the point the Block house is built before the resident and host completing the profiles. See current steps below:

Step 1: Prospective host signs up the program
Step 2: FH team investigates the backyard
Step 3: FH team builds the house  (This is the moment the house backyard photos will be taken by FH team)
Step 4: Host and Caseworker complete the host/resident's profiles 
Step 5: Caseworker and FH team shared host/residents' profiles for the potential pair.
Step 6: Resident is invited to tour the available open Block houses
Step 7: Caseworker/FH team try to find the best match
 
Based on the change, I hid the backyard images for now and am thinking about what is the best way for residents to view the specific houses during Step 5.